### PR TITLE
remove Command in favor of Exec_start

### DIFF
--- a/Parameters.md
+++ b/Parameters.md
@@ -295,12 +295,6 @@ Exec_start
              Command(s) to run in the jail environment when a jail is created.
              A typical command to run is "sh /etc/rc".
 
-Command
-             A synonym for exec.start for use when specifying a jail directly
-             on the command line.  Unlike other parameters whose value is a
-             single string, command uses the remainder of the jail command
-             line as its own arguments.
-
 Exec_poststart
              Command(s) to run in the system environment after a jail is
              created, and after any exec.start commands have completed.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,40 @@ job "test" {
       config {
         Path    = "/zroot/iocage/jails/myjail/root"
 	Persist  = true
-	Ip4_addr = "192.168.1.102"
       }
     }
   }
 }
 ```
+Non vnet jail
+-------------
+```
+job "non-vnet" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "test" {
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "test01" {
+      driver = "jail-task-driver"
+
+      config {
+        Path              = "/zroot/iocage/jails/myjail/root"
+        Ip4               = "new"
+        Allow_raw_sockets = true
+        Allow_chflags     = true
+        Ip4_addr          = "em1|192.168.1.102"
+        Exec_start        = "/usr/local/bin/http-echo -listen :9999 -text hello"
+      }
+    }
+  }
+}
+```
+
 Vnet jail example 
 -----------------
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -95,7 +95,6 @@ var (
 		"Exec_created":          hclspec.NewAttr("Exec_created", "string", false),
 		"Exec_start":            hclspec.NewAttr("Exec_start", "string", false),
 		"Exec_stop":             hclspec.NewAttr("Exec_stop", "string", false),
-		"Command":               hclspec.NewAttr("Command", "string", false),
 		"Exec_poststart":        hclspec.NewAttr("Exec_poststart", "string", false),
 		"Exec_poststop":         hclspec.NewAttr("Exec_poststop", "string", false),
 		"Exec_clean":            hclspec.NewAttr("Exec_clean", "bool", false),
@@ -181,7 +180,7 @@ type Driver struct {
 // Config is the driver configuration set by the SetConfig RPC call
 type Config struct {
 }
-type Rctl  struct {
+type Rctl struct {
 	Cputime         uint `codec:"Cputime"`
 	Datasize        uint `codec:"Datasize"`
 	Coredumpsize    uint `codec:"Coredumpsize"`
@@ -285,7 +284,6 @@ type TaskConfig struct {
 	Exec_created          string `codec:"Exec_created"`
 	Exec_start            string `codec:"Exec_start"`
 	Exec_stop             string `codec:"Exec_stop"`
-	Command               string `codec:"Command"`
 	Exec_poststart        string `codec:"Exec_postart"`
 	Exec_poststop         string `codec:"Exec_poststop"`
 	Exec_clean            bool   `codec:"Exec_clean"`

--- a/driver/jail.go
+++ b/driver/jail.go
@@ -13,8 +13,8 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"os/exec"
+	"path/filepath"
 	"strings"
-"path/filepath"
 )
 
 func simple_uuid() (string, error) {
@@ -165,8 +165,6 @@ func (d *Driver) initializeContainer(cfg *drivers.TaskConfig, taskConfig TaskCon
 
 	if len(taskConfig.Exec_start) > 1 {
 		jailparams["exec.start"] = taskConfig.Exec_start
-	} else if len(taskConfig.Command) > 1 {
-		jailparams["command"] = taskConfig.Command
 	} else if taskConfig.Persist == true {
 		jailparams["persist"] = "true"
 	}

--- a/examples/non-vnet.nomad
+++ b/examples/non-vnet.nomad
@@ -13,6 +13,11 @@ job "test" {
 
       config {
         Path              = "/zroot/iocage/jails/myjail/root"
+        Ip4               = "new"
+        Allow_raw_sockets = true
+        Allow_chflags     = true
+        Ip4_addr          = "em1|192.168.1.102"
+        Exec_start        = "/usr/local/bin/http-echo -listen :9999 -text hello"
       }
     }
   }


### PR DESCRIPTION
Exec_start and Command perform the same function but Command is thought to be executed from the command line, so I'm removing it in favor of Exec_start.
```hcl
task "test01" {
      driver = "jail-task-driver"

      config {
        Path              = "/zroot/iocage/jails/myjail/root"
        Ip4               = "new"
        Allow_raw_sockets = true
        Allow_chflags     = true
        Ip4_addr          = "em1|192.168.1.102"
        Exec_start        = "/usr/local/bin/http-echo -listen :9999 -text hello"
      }
    }
```
This performs the same function.